### PR TITLE
Performance problem with json decorator

### DIFF
--- a/nanohttp/decorators.py
+++ b/nanohttp/decorators.py
@@ -39,7 +39,7 @@ def jsonify(func):
         elif not isinstance(result, (list, dict, int, str)):
             raise ValueError('Cannot encode to json: %s' % type(result))
 
-        return ujson.dumps(result, indent=settings.json.indent)
+        yield ujson.dumps(result, indent=settings.json.indent)
 
     return wrapper
 


### PR DESCRIPTION
After hours i spend for finding why CPU going to hell when i have large requests, finally i found problem is here:
```
from nanohttp import configure, Application, Controller, html, json

class Root(Controller):

    @json
    def index(self):
        return sample_large_output_dict

configure(force=True)
app = Application(root=Root())
```
`sample_large_output_dict` is dumping as json inside of `@json` but returned as string! yes reponse generator try to iterate it and thats it, CPU get in high, character by character. so simply i changed it to generator.